### PR TITLE
Remove parenthesis from "React.Component"

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React from 'react';
 import './App.css';
 import Calculator from './components/calculator';
 
-class App extends React.Component() {
+class App extends React.Component {
   constructor(props) {
     super(props);
     this.state = {};


### PR DESCRIPTION
# Bug fix 🐞 

Bux fixed in [App.js](src/App.js) file:

https://github.com/MacCrazyman/math-magicians/blob/c19f8d48c32399ebadc00f89105909263249bd14/src/App.js#L5

This bug was avoiding the App to render inside the `root` div